### PR TITLE
Guard editor-only safety checks when setting data for GaussianSplats

### DIFF
--- a/Renderite.Unity/Assets/GaussianSplat/GaussianSplatAsset.cs
+++ b/Renderite.Unity/Assets/GaussianSplat/GaussianSplatAsset.cs
@@ -235,12 +235,11 @@ namespace Renderite.Unity
             fixed (void* ptr = data)
             {
                 var native = NativeArrayUnsafeUtility.ConvertExistingDataToNativeArray<T>(ptr, data.Length, Allocator.None);
-
-                // These types don't actually exist at runtime, but are required in the editor.
-                // It works at runtime, but I'm keeping these here in case we need to test in the editor
-                //var safetyHandle = AtomicSafetyHandle.Create();
-                //AtomicSafetyHandle.SetAllowReadOrWriteAccess(safetyHandle, true);
-                //NativeArrayUnsafeUtility.SetAtomicSafetyHandle(ref native, safetyHandle);
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
+                var safetyHandle = AtomicSafetyHandle.Create();
+                AtomicSafetyHandle.SetAllowReadOrWriteAccess(safetyHandle, true);
+                NativeArrayUnsafeUtility.SetAtomicSafetyHandle(ref native, safetyHandle);
+#endif
 
                 buffer.SetData(native);
             }

--- a/Renderite.Unity/Rendering/GaussianSplats/GaussianSplatRenderer.cs
+++ b/Renderite.Unity/Rendering/GaussianSplats/GaussianSplatRenderer.cs
@@ -148,9 +148,11 @@ namespace Renderite.Unity
             fixed (void* ptr = data)
             {
                 var native = NativeArrayUnsafeUtility.ConvertExistingDataToNativeArray<T>(ptr, data.Length, Allocator.None);
+#if ENABLE_UNITY_COLLECTIONS_CHECKS 
                 var safetyHandle = AtomicSafetyHandle.Create();
                 AtomicSafetyHandle.SetAllowReadOrWriteAccess(safetyHandle, true);
                 NativeArrayUnsafeUtility.SetAtomicSafetyHandle(ref native, safetyHandle);
+#endif
 
                 buffer.SetData(native);
             }


### PR DESCRIPTION
As discussed in https://github.com/Yellow-Dog-Man/Renderite.Unity.Renderer/issues/2, the only blocker for actually compiling Renderite.Unity.Renderer in IL2CPP mode is the fact that we're currently using an editor-only safety check that was left in by accident. These usages cause issues for IL2CPP by being available at compile-time but seemingly not available by the time IL2CPP runs over the built DLL.

To fix, cover the usages of safety handles under `ENABLE_UNITY_COLLECTIONS_CHECKS`.

As a technical note, these defines aren't technically able to be enabled automatically since this project isn't actually built in Unity which would normally define them under the right conditions. So if you're testing this it'll have to be defined manually in the csproj file or something similar.