### PR TITLE
Fix window icon not setting on some Linux desktop environments

### DIFF
--- a/Renderite.Unity/RenderingManager.cs
+++ b/Renderite.Unity/RenderingManager.cs
@@ -1502,7 +1502,10 @@ namespace Renderite.Unity
             bool success;
 
             if (!icon.isOverlay)
-                success = WindowIconTools.SetIcon(iconData, icon.size.x, icon.size.y, WindowIconKind.Big);
+            {
+                success = WindowIconTools.SetIcon(iconData, icon.size.x, icon.size.y, WindowIconKind.Small);
+                success &= WindowIconTools.SetIcon(iconData, icon.size.x, icon.size.y, WindowIconKind.Big);
+            }
             else
                 success = WindowIconTools.SetOverlayIcon(iconData, icon.size.x, icon.size.y, icon.overlayDescription ?? "");
 


### PR DESCRIPTION
Closes https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/5670

To reiterate [my hunch from September](https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/5670#issuecomment-3325825907) Basically, `Big` and `Small` `WindowIconKind`s are used for [different purposes in Windows](https://learn.microsoft.com/en-us/windows/win32/winmsg/wm-seticon), and Wine/Linux desktop environments also seem to interpret them in their own ways.

There are many examples in Wine code where they set both a `Small` and `Big` icon, so I've used that behavior here and it fixes the window icon on KDE!

<img width="370" height="241" alt="image" src="https://github.com/user-attachments/assets/b51d418a-28bb-4037-bede-9674497c15dc" />

Wine doesn't have support for overlay icons at all so that won't work but theoretically if it was implemented in Wine it should just work.

Tested on Windows in a VM and there seems to be no regression.