### PR TITLE
Small patch to stop dash dual rendering in VR

### DIFF
--- a/Renderite.Unity/RenderingManager.cs
+++ b/Renderite.Unity/RenderingManager.cs
@@ -586,7 +586,7 @@ namespace Renderite.Unity
 
                 UpdateQualitySettings(vrActive);
             }           
-
+            Instance.OverlayCamera.gameObject.SetActive(!vrActive);
             return activeOutput;
         }
 


### PR DESCRIPTION
Its one of the things I added for unity 6000 noticing that the Overlaycam kept staying on when in VR despite not needing to be on. gives a tiny bump to performance from my testing, otherwise doesn't seem to change anything beyond that. No issue in Resonite-Issues that I noticed and when searching.