### PR TITLE
implement path translation

### DIFF
--- a/Renderite.Shared/Helper.cs
+++ b/Renderite.Shared/Helper.cs
@@ -34,5 +34,25 @@ namespace Renderite.Shared
 
         [DllImport("ntdll.dll", EntryPoint = "wine_get_version", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
         private static extern string wine_get_version();
+        
+        [DllImport("kernel32.dll", EntryPoint = "wine_get_unix_file_name", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+        private static extern IntPtr wine_get_unix_file_name(string path);
+        
+        public static string? DosToUnix(string path)
+        {
+            IntPtr ptr = wine_get_unix_file_name(path);
+
+            if (ptr == IntPtr.Zero)
+                return null;
+
+            try
+            {
+                return Marshal.PtrToStringAnsi(ptr);
+            }
+            catch
+            {
+                return null;
+            }
+        }
     }
 }


### PR DESCRIPTION
this adds a wine helper function which can translate dos paths to unix paths, which can be used for drag and drop path translation.

This pull request is required for https://github.com/Yellow-Dog-Man/Renderite.Unity.Renderer/pull/38