### PR TITLE
Dirty fix for skinned meshes failing to reupload

### DIFF
--- a/Renderite.Unity/Assets/Mesh/MeshAsset.cs
+++ b/Renderite.Unity/Assets/Mesh/MeshAsset.cs
@@ -73,6 +73,7 @@ namespace Renderite.Unity
 
         bool firstUploadCompleted;
         IndexBufferFormat? lastIndexBufferFormat;
+        bool lastIsSkinned;
 
         void UpdateVertexLayout(MeshBuffer buffer, UnityEngine.Mesh mesh)
         {
@@ -258,13 +259,15 @@ namespace Renderite.Unity
                 Debug.Log($"Uploading Mesh {AssetId} (first: {!firstUploadCompleted}): {meshBuffer}\nHint: " + uploadHint +
                     "\nBounds: " + uploadData.bounds);
 
-            if (mesh != null && !mesh.isReadable)
+            if (mesh != null && (!mesh.isReadable || lastIsSkinned))
             {
                 if (mesh)
                     UnityEngine.Object.Destroy(mesh);
 
                 mesh = null;
             }
+
+            lastIsSkinned = false;
 
             bool instanceChanged = false;
 
@@ -330,6 +333,8 @@ namespace Renderite.Unity
                 if (!firstUploadCompleted)
                     yield return null;
 
+                lastIsSkinned = true;
+
                 UploadBonesBuffer(meshBuffer, mesh);
             }
 
@@ -338,6 +343,8 @@ namespace Renderite.Unity
             if (uploadHint[MeshUploadHint.Flag.Blendshapes] && meshBuffer.BlendshapeBufferCount > 0)
             {
                 yield return null;
+
+                lastIsSkinned = true;
 
                 if ((mesh.bindposes?.Length ?? 0) == 0)
                 {


### PR DESCRIPTION
I've added a new procedural mesh to Resonite to visualize bone weights, but I ran into issue with the mesh uploads failing with Unity error `Bones do not match bindpose.`

I've looked into it a bit, but I could not find a quick fix for updating existing data - it seems once bone bindings are assigned, trying to update them again results in this error, even if I try to clear them first.

Given that we want to move away from Unity and that procedural skinned meshes are not that common, this fix just forces the whole mesh to be rebuilt (there are corresponding changes FrooxEngine side to force all buffers to be updated), rather than existing instance being updated.

It's less efficient, but still fast enough.

If anyone's willing to poke at this and make this more efficient, feel free!