### PR TITLE
Fixed edge case when updating skinned meshes

### DIFF
--- a/Renderite.Unity/Assets/Mesh/MeshAsset.cs
+++ b/Renderite.Unity/Assets/Mesh/MeshAsset.cs
@@ -259,7 +259,7 @@ namespace Renderite.Unity
                 Debug.Log($"Uploading Mesh {AssetId} (first: {!firstUploadCompleted}): {meshBuffer}\nHint: " + uploadHint +
                     "\nBounds: " + uploadData.bounds);
 
-            if (mesh != null && (!mesh.isReadable || lastIsSkinned))
+            if (mesh != null && (!mesh.isReadable || lastIsSkinned || uploadHint[MeshUploadHint.Flag.BindPoses]))
             {
                 if (mesh)
                     UnityEngine.Object.Destroy(mesh);


### PR DESCRIPTION
Following previous fix, this addresses another edge case I ran into, where the mesh happens to be non-skinned and gets updated to a skinned mesh data with subsequent update.