### PR TITLE
Windows IME composition/preedit payload over Renderite KeyboardState

### DIFF
--- a/Renderite.Shared/Models/Input/KeyboardState.cs
+++ b/Renderite.Shared/Models/Input/KeyboardState.cs
@@ -7,22 +7,25 @@ namespace Renderite.Shared
 {
     public class KeyboardState : IMemoryPackable
     {
-        
-        public string typeDelta;
-
-        
+        public string? typeDelta;
         public HashSet<Key> heldKeys = new HashSet<Key>();
+        public bool compositionActive;
+        public string? compositionText;
 
         public void Pack(ref MemoryPacker packer)
         {
             packer.Write(typeDelta);
             packer.WriteValueList(heldKeys);
+            packer.Write(compositionActive);
+            packer.Write(compositionText);
         }
 
         public void Unpack(ref MemoryUnpacker packer)
         {
             packer.Read(ref typeDelta);
             packer.ReadValueList(ref heldKeys);
+            packer.Read(ref compositionActive);
+            packer.Read(ref compositionText);
         }
     }
 }

--- a/Renderite.Shared/Models/Output/OutputState.cs
+++ b/Renderite.Shared/Models/Output/OutputState.cs
@@ -14,6 +14,8 @@ namespace Renderite.Shared
         
         public bool keyboardInputActive;
 
+        public RenderVector2? compositionCursorPosition;
+
         public VR_OutputState vr;
 
         public void Pack(ref MemoryPacker packer)
@@ -21,6 +23,7 @@ namespace Renderite.Shared
             packer.Write(lockCursor);
             packer.Write(lockCursorPosition);
             packer.Write(keyboardInputActive);
+            packer.Write(compositionCursorPosition);
 
             packer.WriteObject(vr);
         }
@@ -30,6 +33,7 @@ namespace Renderite.Shared
             packer.Read(ref lockCursor);
             packer.Read(ref lockCursorPosition);
             packer.Read(ref keyboardInputActive);
+            packer.Read(ref compositionCursorPosition);
 
             packer.ReadObject(ref vr);
         }


### PR DESCRIPTION
This is the implementation of the shared model section of [#47](https://github.com/Yellow-Dog-Man/Renderite.Unity.Renderer/pull/47). Please refer to that section for further details.