### PR TITLE
feat: setup unit test projects and workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,51 @@
+name: Test Renderite Library
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - '**.cs'
+      - '**.csproj'
+      - '**.props'
+      - '**/testconfig.json'
+      - 'global.json'
+  pull_request:
+    paths:
+      - '**.cs'
+      - '**.csproj'
+      - '**.props'
+      - '**/testconfig.json'
+      - 'global.json'
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+permissions:
+  contents: read
+  actions: read
+  checks: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout repository'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Run tests
+        run: dotnet test --configuration Release
+
+      - name: Generate test report
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # V3.0.0
+        with:
+          name: Renderite.Test
+          path: '**/TestResults/**/*.trx'
+          reporter: dotnet-trx

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ on:
       - '**.props'
       - '**/testconfig.json'
       - 'global.json'
+      - '**/test.yml'
   pull_request:
     paths:
       - '**.cs'
@@ -16,6 +17,7 @@ on:
       - '**.props'
       - '**/testconfig.json'
       - 'global.json'
+      - '**/test.yml'
 
 env:
   DOTNET_NOLOGO: true
@@ -40,7 +42,7 @@ jobs:
           dotnet-version: 10.0.x
 
       - name: Run tests
-        run: dotnet test --configuration Release
+        run: dotnet test --project ./Renderite.Shared.Tests/Renderite.Shared.Tests.csproj  --configuration Release
 
       - name: Generate test report
         if: ${{ !cancelled() }}

--- a/Renderite.Shared.Tests/MathHelperTests.cs
+++ b/Renderite.Shared.Tests/MathHelperTests.cs
@@ -1,0 +1,74 @@
+﻿namespace Renderite.Shared.Tests;
+
+[TestClass]
+public class MathHelperTests
+{
+    private const float FallbackFloatValue = 0.4f;
+
+    /// <summary>
+    /// Verifies that <see cref="MathHelper.FilterInvalid"/> returns the fallback value when an invalid float
+    /// (NaN or Infinity) is passed.
+    /// </summary>
+    /// <remarks>
+    /// The expected value should be the provided fallback value if it is not null; otherwise, it should be the
+    /// default value for float (0.0f).
+    /// </remarks>
+    /// <param name="valueToPass">The invalid float value to pass in.</param>
+    /// <param name="fallback">The fallback value to use.</param>
+    /// <param name="expectedValue">The expected value to be returned.</param>
+    [TestMethod(UnfoldingStrategy = TestDataSourceUnfoldingStrategy.Unfold)]
+    [DataRow([float.NaN, FallbackFloatValue, FallbackFloatValue])]
+    [DataRow([float.NaN, null, default(float)])]
+    [DataRow([float.NegativeInfinity, FallbackFloatValue, FallbackFloatValue])]
+    [DataRow([float.NegativeInfinity, null, default(float)])]
+    [DataRow([float.PositiveInfinity, FallbackFloatValue, FallbackFloatValue])]
+    [DataRow([float.PositiveInfinity, null, default(float)])]
+    public void FilterInvalid_InvalidFloat_ReturnsFallback(float valueToPass, float? fallback, float expectedValue)
+    {
+        var actualValue = fallback.HasValue
+            ? MathHelper.FilterInvalid(valueToPass, fallback.Value)
+            : MathHelper.FilterInvalid(valueToPass);
+
+        Assert.AreEqual(expectedValue, actualValue);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MathHelper.FilterInvalid"/> returns the passed in float value if it is a valid float.
+    /// </summary>
+    /// <remarks>
+    /// The expected value should be the same as the passed in float value since it is valid.
+    /// </remarks>
+    /// <param name="expectedValue">The expected value to be returned.</param>
+    [TestMethod]
+    [DataRow(3.2f)]
+    [DataRow(-3.2f)]
+    [DataRow(default(float))]
+    public void FilterInvalid_ValidFloat_ReturnsSameFloat(float expectedValue)
+    {
+        var actualValue = MathHelper.FilterInvalid(expectedValue);
+
+        Assert.AreEqual(expectedValue, actualValue);
+    }
+
+    [TestMethod(UnfoldingStrategy = TestDataSourceUnfoldingStrategy.Unfold)]
+    [DataRow([ulong.MinValue, 0])]
+    [DataRow([(ulong)1, 1])]
+    [DataRow([(ulong)1 << 1, 2])]
+    [DataRow([(ulong)1 << 2, 3])]
+    [DataRow([(ulong)1 << 3, 4])]
+    [DataRow([(ulong)1 << 7, 8])]
+    [DataRow([(ulong)1 << 15, 16])]
+    [DataRow([(ulong)1 << 23, 24])]
+    [DataRow([(ulong)1 << 31, 32])]
+    [DataRow([(ulong)1 << 39, 40])]
+    [DataRow([(ulong)1 << 47, 48])]
+    [DataRow([(ulong)1 << 55, 56])]
+    [DataRow([(ulong)1 << 63, 64])]
+    [DataRow([ulong.MaxValue, 64])]
+    public void GetNecessaryBits_UInt64Value_ReturnsCorrectBitCount(ulong number, int expectedBits)
+    {
+        var actualBits = MathHelper.NecessaryBits(number);
+
+        Assert.AreEqual(expectedBits, actualBits);
+    }
+}

--- a/Renderite.Shared.Tests/Renderite.Shared.Tests.csproj
+++ b/Renderite.Shared.Tests/Renderite.Shared.Tests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="MSTest.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+	<UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+	<MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.mtp" Version="10.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Renderite.Shared\Renderite.Shared.csproj" />
+  </ItemGroup>
+	
+  <ItemGroup>
+    <None Update="testconfig.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/Renderite.Shared.Tests/testconfig.json
+++ b/Renderite.Shared.Tests/testconfig.json
@@ -1,0 +1,18 @@
+{
+  "platformOptions": {
+    "resultDirectory": "./TestResults/ByProject/Renderite.Shared/",
+    "Coverlet": {
+      "exclude": "[*.Tests]*",
+      "includeTestAssembly": false,
+      "excludeAssembliesWithoutSources": "MissingAll"
+    }
+  },
+  "commandLineOptions": {
+    "report-trx": true,
+    "coverlet": true,
+    "coverlet-output-format": [
+      "cobertura",
+      "json"
+    ]
+  }
+}

--- a/Renderite.Unity.Tests/Input/MouseInputTests.cs
+++ b/Renderite.Unity.Tests/Input/MouseInputTests.cs
@@ -1,0 +1,66 @@
+﻿using Renderite.Shared;
+using System.Runtime.CompilerServices;
+
+namespace Renderite.Unity.Tests;
+
+[TestClass]
+public sealed class MouseInputTests
+{
+    [TestMethod]
+    public void UpdateState_MouseStateProvided_UpdatesWithExistingMouseState()
+    {
+        MouseState expectedMouseState = new();
+        var mockMouseInput = (TestMouseInput)RuntimeHelpers.GetUninitializedObject(typeof(TestMouseInput));
+
+        InputState mockInputState = new()
+        {
+            mouse = expectedMouseState
+        };
+
+        mockMouseInput.UpdateState(mockInputState);
+
+        Assert.AreEqual(1, mockMouseInput.UpdateStateCallCount);
+        Assert.AreEqual(expectedMouseState, mockMouseInput.ActualMouseState);
+    }
+
+    [TestMethod]
+    public void UpdateState_MouseStateIsNull_UpdatesWithNewMouseState()
+    {
+        var mockMouseInput = (TestMouseInput)RuntimeHelpers.GetUninitializedObject(typeof(TestMouseInput));
+
+        InputState mockInputState = new()
+        {
+            // This is awkward; however, MouseInput has a null check, so it has to be done.
+            mouse = null!
+        };
+        Assert.IsNull(mockMouseInput.ActualMouseState);
+
+        mockMouseInput.UpdateState(mockInputState);
+
+        Assert.AreEqual(1, mockMouseInput.UpdateStateCallCount);
+        Assert.IsNotNull(mockMouseInput.ActualMouseState);
+    }
+}
+
+file sealed class TestMouseInput : MouseInput
+{
+    public int UpdateStateCallCount { get; private set; }
+
+    public int HandleStateUpdateCallCount { get; private set; }
+
+    public MouseState? ActualMouseState { get; private set; }
+
+    public OutputState? ActualOutputState { get; private set; }
+
+    public override void HandleStateUpdate(OutputState state)
+    {
+        HandleStateUpdateCallCount++;
+        ActualOutputState = state;
+    }
+
+    protected override void UpdateState(MouseState state)
+    {
+        UpdateStateCallCount++;
+        ActualMouseState = state;
+    }
+}

--- a/Renderite.Unity.Tests/Renderite.Unity.Tests.csproj
+++ b/Renderite.Unity.Tests/Renderite.Unity.Tests.csproj
@@ -1,0 +1,43 @@
+﻿<Project Sdk="MSTest.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+	<UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+	<MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.mtp" Version="10.0.1" />
+    <PackageReference Include="Unity3D" Version="3.1.1" />
+  </ItemGroup>
+	
+  <PropertyGroup>
+    <UnityVersion>2019.4.19f1</UnityVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Renderite.Unity\Renderite.Unity.csproj" />
+  </ItemGroup>
+	
+  <ItemGroup>
+    <None Update="testconfig.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+	
+  <Target Name="MakeUnityAssembliesCopyLocal" BeforeTargets="ResolveAssemblyReferences">
+    <ItemGroup>
+      <Reference Update="$(UnityModulesPath)\UnityEngine.dll">
+        <Private>true</Private>
+      </Reference>
+
+      <Reference Update="$(UnityModulesPath)\UnityEngine.*Module.dll">
+        <Private>true</Private>
+      </Reference>
+    </ItemGroup>
+  </Target>
+	
+</Project>

--- a/Renderite.Unity.Tests/testconfig.json
+++ b/Renderite.Unity.Tests/testconfig.json
@@ -1,0 +1,18 @@
+{
+  "platformOptions": {
+    "resultDirectory": "./TestResults/ByProject/Renderite.Unity/",
+    "Coverlet": {
+      "exclude": "[*.Tests]*",
+      "includeTestAssembly": false,
+      "excludeAssembliesWithoutSources": "MissingAll"
+    }
+  },
+  "commandLineOptions": {
+    "report-trx": true,
+    "coverlet": true,
+    "coverlet-output-format": [
+      "cobertura",
+      "json"
+    ]
+  }
+}

--- a/Renderite.slnx
+++ b/Renderite.slnx
@@ -5,6 +5,7 @@
   </Folder>
   <Folder Name="/Solution Items/">
     <File Path="global.json" />
+    <File Path="Test-WithCoverage.ps1" />
   </Folder>
   <Project Path="Renderite.Shared.Tests/Renderite.Shared.Tests.csproj" />
   <Project Path="Renderite.Shared/Renderite.Shared.csproj" />

--- a/Renderite.slnx
+++ b/Renderite.slnx
@@ -1,4 +1,13 @@
 <Solution>
+  <Folder Name="/.github_workflows/">
+    <File Path=".github/workflows/nuget-build.yml" />
+    <File Path=".github/workflows/test.yml" />
+  </Folder>
+  <Folder Name="/Solution Items/">
+    <File Path="global.json" />
+  </Folder>
+  <Project Path="Renderite.Shared.Tests/Renderite.Shared.Tests.csproj" />
   <Project Path="Renderite.Shared/Renderite.Shared.csproj" />
+  <Project Path="Renderite.Unity.Tests/Renderite.Unity.Tests.csproj" />
   <Project Path="Renderite.Unity/Renderite.Unity.csproj" />
 </Solution>

--- a/Test-WithCoverage.ps1
+++ b/Test-WithCoverage.ps1
@@ -1,0 +1,51 @@
+# The '--coverlet' switch should be passed automatically as long as 'TestingPlatformCommandLineArguments' was set.
+
+$reportDirectory = Join-Path $PSScriptRoot "TestResults" "CoverageReports"
+$reportTypes = "Html,TextSummary"
+
+dotnet test
+
+if ($LASTEXITCODE -ne 0) {
+	exit $LASTEXITCODE
+}
+
+# Obtain latest coverage files for each project.
+
+$coverageProjectDirs = Get-ChildItem -Path $PSScriptRoot -Filter "coverage.cobertura*.xml" -File -Recurse | Group-Object DirectoryName
+
+$coverageFiles =  $coverageProjectDirs | ForEach-Object {
+	$_.Group | Sort-Object LastWriteTimeUtc -Descending | Select-Object -First 1
+}
+
+if (-not $coverageFiles) {
+	throw "No Cobertura files were found. Unable to generate coverage report."
+}
+
+# Generate a visual, human readable report with ReportGenerator.
+
+$reports = $coverageFiles.FullName -join ";"
+
+dotnet reportgenerator "-reports:$reports" "-targetDir:$reportDirectory" "-reporttypes:$reportTypes" "-verbosity:Warning"
+
+if ($LASTEXITCODE -ne 0) {
+	exit $LASTEXITCODE
+}
+
+# Replace string instances of CRAP, which stands for Change Risk Anti-Patterns, to "Change Risk Score" instead.
+
+Get-ChildItem $reportDirectory -Include "*.htm", "*.html", "*.js"  -Recurse -File |
+	ForEach-Object {
+		$content = Get-Content $_.FullName -Raw
+
+		$content = [regex]::Replace($content, "CRAP Score", "Change Risk Score", [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+
+		Out-File -FilePath $_.FullName -InputObject $content
+	}
+
+# Output the text summary and the location of the HTML file.
+
+Write-Host $(Get-Content (Join-Path $reportDirectory "Summary.txt") -Raw)
+Write-Host
+
+Write-Host "HTML report path: $(Join-Path $reportDirectory "index.html")"
+Write-Host

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-reportgenerator-globaltool": {
+      "version": "5.5.11",
+      "commands": [
+        "reportgenerator"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/global.json
+++ b/global.json
@@ -1,0 +1,8 @@
+{
+  "msbuild-sdks": {
+    "MSTest.Sdk": "4.3.3"
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}


### PR DESCRIPTION
This PR adds test projects to support the repository's testing efforts. Because the repository contains two production projects, two corresponding test projects have been created:

* `Renderite.Shared.Tests`
* `Renderite.Unity.Tests`

Both tests can be run locally using either the `dotnet test` command or Test Explorer. The test projects use the newer Microsoft Testing Platform (MTP) instead of the legacy VSTest platform.

Each project includes a small number of tests to verify that the test infrastructure has been configured correctly. The following tests are currently included:

* `Renderite.Shared.Tests` contains a test for the `FilterInvalid` method and `NecessaryBit` method in `MathHelper`
* `Renderite.Unity.Tests` contains a test that fully verifies the `MouseInput` class.

For CI, only `Renderite.Shared.Tests` will run when a pull request is created. `Renderite.Unity.Tests` will not currently run in CI because of the additional complexity introduced by its dependency on `UnityEngine`. This may be addressed later, but I did not want it to delay the addition of the test projects.

Local code-coverage reporting has also been configured. The repository root now contains a `Test-WithCoverage.ps1` script that can be manually run from a terminal to execute all test projects and generate both a text-based coverage summary in the terminal and a visual coverage report.

The following image shows an example of the visual coverage report:

<img width="754" height="696" alt="image" src="https://github.com/user-attachments/assets/3122f175-c77f-4999-9996-bad9610937eb" />

For now, the primary purpose of these projects is to provide a place for unit tests. When _integration tests_ are introduced, a separate test project can be created to keep the unit and integration test suites distinct.

Resolves #19 