### PR TITLE
RenderTexture readback

### DIFF
--- a/Renderite.Shared/Models/Assets/Textures/RenderTexture/RenderTextureReadbackResult.cs
+++ b/Renderite.Shared/Models/Assets/Textures/RenderTexture/RenderTextureReadbackResult.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Renderite.Shared
+{
+    /// <summary>
+    /// Indicates that readback from a render texture has completed and the buffer data can be
+    /// processed and disposed.
+    /// </summary>
+    public class RenderTextureReadbackResult : AssetCommand
+    {
+        /// <summary>
+        /// Unique ID for the readback task. This will match the same value of the readback task
+        /// and is used to match the result to specific task.
+        /// </summary>
+        public int readbackTaskId;
+
+        /// <summary>
+        /// Indicates if the readback was success. If false, then the buffer data is likely invalid
+        /// and should not be processed
+        /// </summary>
+        public bool success;
+    }
+}

--- a/Renderite.Shared/Models/Assets/Textures/RenderTexture/RenderTextureReadbackTask.cs
+++ b/Renderite.Shared/Models/Assets/Textures/RenderTexture/RenderTextureReadbackTask.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Renderite.Shared
+{
+    /// <summary>
+    /// Request to read back texture data from a given render texture. 
+    /// This should use async GPU readbacks for efficiency on the renderer.
+    /// It will give whatever data is currently in the render texture
+    /// </summary>
+    public class RenderTextureReadbackTask : AssetCommand
+    {
+        /// <summary>
+        /// Unique ID for the readback task. Since this process is asynchronous and can take several frames
+        /// and there can be multiple concurrent requests (even for the same render texture), we need to
+        /// identify each one uqiquely when the read back data is returned
+        /// </summary>
+        public int readbackTaskId;
+
+        /// <summary>
+        /// Buffer to fill the rendered data. This represents raw bitmap data. The size MUST match
+        /// the given render texture dimensions and requested readbackFormat.
+        /// </summary>
+        public SharedMemoryBufferDescriptor<byte> resultData;
+
+        /// <summary>
+        /// Texture format of the read back data. This can be used to read back textures as RGB24 for example
+        /// when alpha channel is not needed, reducing the overall amount of bandwidth.
+        /// </summary>
+        public TextureFormat readbackFormat;
+
+        public override void Pack(ref MemoryPacker packer)
+        {
+            base.Pack(ref packer);
+
+            packer.Write(readbackTaskId);
+            packer.Write(resultData);
+            packer.Write(readbackFormat);
+        }
+
+        public override void Unpack(ref MemoryUnpacker packer)
+        {
+            base.Unpack(ref packer);
+
+            packer.Read(ref readbackTaskId);
+            packer.Read(ref resultData);
+            packer.Read(ref readbackFormat);
+        }
+    }
+}

--- a/Renderite.Shared/Models/FrameCycle/FrameSubmitData.cs
+++ b/Renderite.Shared/Models/FrameCycle/FrameSubmitData.cs
@@ -30,6 +30,8 @@ namespace Renderite.Shared
         
         public List<CameraRenderTask> renderTasks;
 
+        public List<RenderTextureReadbackTask> readbackTasks;
+
         public override void Pack(ref MemoryPacker packer)
         {
             packer.Write(frameIndex);
@@ -46,6 +48,7 @@ namespace Renderite.Shared
 
             packer.WriteObjectList(renderSpaces);
             packer.WriteObjectList(renderTasks);
+            packer.WriteObjectList(readbackTasks);
         }
 
         public override void Unpack(ref MemoryUnpacker packer)
@@ -63,6 +66,7 @@ namespace Renderite.Shared
 
             packer.ReadObjectList(ref renderSpaces);
             packer.ReadObjectList(ref renderTasks);
+            packer.ReadObjectList(ref readbackTasks);
         }
     }
 }

--- a/Renderite.Shared/Models/RendererCommand.cs
+++ b/Renderite.Shared/Models/RendererCommand.cs
@@ -71,6 +71,8 @@ namespace Renderite.Shared
                 typeof(SetRenderTextureFormat),
                 typeof(RenderTextureResult),
                 typeof(UnloadRenderTexture),
+                typeof(RenderTextureReadbackTask),
+                typeof(RenderTextureReadbackResult),
 
                 typeof(SetDesktopTextureProperties),
                 typeof(DesktopTexturePropertiesUpdate),

--- a/Renderite.Unity/Assets/Texture/RenderTextureAsset.cs
+++ b/Renderite.Unity/Assets/Texture/RenderTextureAsset.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using UnityEngine;
+using UnityEngine.Rendering;
 
 namespace Renderite.Unity
 {
@@ -24,6 +25,27 @@ namespace Renderite.Unity
             RenderingManager.Instance.RenderTextures.RemoveAsset(this);
 
             PackerMemoryPool.Instance.Return(unload);
+        }
+
+        public void Handle(RenderTextureReadbackTask task)
+        {
+            // Do the readback directly into the buffer to avoid unecessary copies
+            var buffer = RenderingManager.Instance.SharedMemory.AccessAsNativeArray(task.resultData);
+
+            // Capture the task data. Since this is async processing, the task will be disposed before this completes
+            // so we need to capture it here
+            var result = new RenderTextureReadbackResult();
+            result.assetId = AssetId;
+            result.readbackTaskId = task.readbackTaskId;
+
+            AsyncGPUReadback.RequestIntoNativeArray(ref buffer, Texture, 0, task.readbackFormat.ToUnity(), readbackResult =>
+            {
+                // Indicate if this succeeded or not
+                result.success = !readbackResult.hasError;
+
+                // Inform the engine that this has completed and they can process the read back data
+                RenderingManager.Instance.SendAssetUpdate(result);
+            });
         }
 
         void ApplyUpdate(object untypedFormat)

--- a/Renderite.Unity/IPC/SharedMemoryAccessor.cs
+++ b/Renderite.Unity/IPC/SharedMemoryAccessor.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
+using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
 
 namespace Renderite.Unity
 {
@@ -35,6 +37,13 @@ namespace Renderite.Unity
                     $"Offset: {descriptor.offset}, Length: {descriptor.length}, BufferCapacity: {descriptor.bufferCapacity}, BufferId: {descriptor.bufferId}");
                 throw;
             }
+        }
+
+        public unsafe NativeArray<T> AccessAsNativeArray<T>(SharedMemoryBufferDescriptor<T> descriptor)
+            where T : unmanaged
+        {
+            var view = GetMemoryView(descriptor);
+            return NativeArrayUnsafeUtility.ConvertExistingDataToNativeArray<T>(view.Pointer + descriptor.offset, descriptor.length, Allocator.None);
         }
 
         public UnmanagedSpan<T> AccessDataUnmanaged<T>(SharedMemoryBufferDescriptor<T> descriptor)

--- a/Renderite.Unity/IPC/SharedMemoryView.cs
+++ b/Renderite.Unity/IPC/SharedMemoryView.cs
@@ -12,6 +12,7 @@ namespace Renderite.Unity
 
         public Span<byte> RawData => view.Data;
         public Memory<byte> Memory => memory.Memory;
+        public unsafe byte* Pointer => view.Pointer;
         public unsafe UnmanagedSpan<byte> UnmanagedRawData => new UnmanagedSpan<byte>(view.Pointer, (int)capacity);
 
         MemoryView view;

--- a/Renderite.Unity/RenderingManager.cs
+++ b/Renderite.Unity/RenderingManager.cs
@@ -521,7 +521,7 @@ namespace Renderite.Unity
                     Debug.Log($"{DateTime.Now.ToMillisecondTimeString()} PROCESSED FRAME {data.frameIndex}");
 
                 // Check if there's any render tasks. If there's any, we'll need to run those after the frame has finished
-                if(data.renderTasks == null)
+                if(data.renderTasks == null && data.readbackTasks == null)
                     PackerMemoryPool.Instance.Return(data);
                 else
                 {
@@ -556,7 +556,12 @@ namespace Renderite.Unity
 
                 if(_dataWithRenderTasks != null)
                 {
-                    ProcessRenderTasks(_dataWithRenderTasks.renderTasks);
+                    if(_dataWithRenderTasks.readbackTasks != null)
+                        ProcessRenderTasks(_dataWithRenderTasks.renderTasks);
+
+                    if (_dataWithRenderTasks.readbackTasks != null)
+                        ProcessReadbackTasks(_dataWithRenderTasks.readbackTasks);
+
                     PackerMemoryPool.Instance.Return(_dataWithRenderTasks);
 
                     _dataWithRenderTasks = null;
@@ -1193,6 +1198,12 @@ namespace Renderite.Unity
                 RenderContextHelper.BeginRenderContext(previousContext.Value);
             else
                 RenderContextHelper.EndCurrentRenderContext();
+        }
+
+        void ProcessReadbackTasks(List<RenderTextureReadbackTask> readbackTasks)
+        {
+            foreach(var task in readbackTasks)
+                RenderTextures.GetAsset(task.readbackTaskId).Handle(task);
         }
 
         bool GetConnectionParameters(out string queueName, out long queueCapacity)


### PR DESCRIPTION
This adds ability for efficient async readback of RenderTexture data.

It's intended as a building block for this: https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/4154

But has potential other uses as well for capturing screenshots from RenderTextures (rather than a distinct render) which could capture them with state like motion blur.