### PR TITLE
Add additional source URL to the model for loading video textures

### DIFF
--- a/Renderite.Shared/Models/Assets/Textures/Video/VideoTextureLoad.cs
+++ b/Renderite.Shared/Models/Assets/Textures/Video/VideoTextureLoad.cs
@@ -7,6 +7,7 @@ namespace Renderite.Shared
     public class VideoTextureLoad : AssetCommand
     {
         public string source;
+        public string additionalSource;
         public string overrideEngine;
         public string mimeType;
         public bool isStream;
@@ -18,6 +19,7 @@ namespace Renderite.Shared
             base.Pack(ref packer);
 
             packer.Write(source);
+            packer.Write(additionalSource);
             packer.Write(overrideEngine);
             packer.Write(mimeType);
             packer.Write(isStream);
@@ -29,6 +31,7 @@ namespace Renderite.Shared
             base.Unpack(ref packer);
 
             packer.Read(ref source);
+            packer.Read(ref additionalSource);
             packer.Read(ref overrideEngine);
             packer.Read(ref mimeType);
             packer.Read(ref isStream);

--- a/Renderite.Unity/Assets/Video/IVideoPlaybackInstance.cs
+++ b/Renderite.Unity/Assets/Video/IVideoPlaybackInstance.cs
@@ -11,7 +11,7 @@ namespace Renderite.Unity
     public interface IVideoPlaybackInstance
     {
         bool IsLoaded { get; }
-        IEnumerator Setup(VideoTextureAsset asset, string dataSource, int audioSystemSampleRate);
+        IEnumerator Setup(VideoTextureAsset asset, string dataSource, string additionalDataSource, int audioSystemSampleRate);
 
         double Length { get; }
         Vector2Int Size { get; }

--- a/Renderite.Unity/Assets/Video/VideoTextureAsset.cs
+++ b/Renderite.Unity/Assets/Video/VideoTextureAsset.cs
@@ -115,7 +115,7 @@ namespace Renderite.Unity
 
                     var instance = engine.Instantiate(Manager.gameObject);
 
-                    yield return instance.Setup(this, load.source, load.audioSystemSampleRate);
+                    yield return instance.Setup(this, load.source, load.additionalSource, load.audioSystemSampleRate);
 
                     if (instance.IsLoaded && !_cancellationToken.IsCancellationRequested)
                     {


### PR DESCRIPTION
This can be used for playback of sources where audio & video are separate. The goal is to use the `--input-slave` option in libVLC for live muxing YouTube videos.